### PR TITLE
Added default WP 5.5 lazyloading.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,96 +1,107 @@
 # Change log
 
+## 1.2.4 - In development
+
+### Added
+
+- Added default WP 5.5 lazyloading.
 
 ## [[1.2.3]](https://github.com/lightspeeddevelopment/lsx-testimonials/releases/tag/1.2.3) - 2020-03-30
 
 ### Added
+
 - Adding support for the WordPress REST API.
 - Adding 'Tag' taxonomy.
 
 ### Fixed
+
 - Fixed issue `PHP Deprecated: dbx_post_advanced is deprecated since version 3.7.0! Use add_meta_boxes instead`.
 
 ### Security
+
 - Updating dependencies to prevent vulnerabilities.
 - General testing to ensure compatibility with latest WordPress version (5.4).
 - General testing to ensure compatibility with latest LSX Theme version (2.7).
 
-
 ## [[1.2.2]](https://github.com/lightspeeddevelopment/lsx-testimonials/releases/tag/1.2.2) - 2019-12-19
 
 ### Security
+
 - General testing to ensure compatibility with latest WordPress version (5.3).
 - Checking compatibility with LSX 2.6 release.
-
 
 ## [[1.2.1]](https://github.com/lightspeeddevelopment/lsx-testimonials/releases/tag/1.2.1) - 2019-11-13
 
 ### Fixed
-- Fixing the ` Undefined variable: col_enabled` error.
 
+- Fixing the `Undefined variable: col_enabled` error.
 
 ## [[1.2.0]](https://github.com/lightspeeddevelopment/lsx-testimonials/releases/tag/1.2.0) - 2019-10-01
 
 ### Added
+
 - Adding the .gitattributes file to remove unnecessary files from the WordPress version.
 - Added in lazyloading for the sliders.
 - Added in a "Review" Schema using the Yoast API.
 
-
 ## [[1.1.8]](https://github.com/lightspeeddevelopment/lsx-testimonials/releases/tag/1.1.8) - 2019-09-27
 
 ### Added
-- Added in the Review Schema integrated with Yoast WordPress SEO.
 
+- Added in the Review Schema integrated with Yoast WordPress SEO.
 
 ## [[1.1.7]](https://github.com/lightspeeddevelopment/lsx-testimonials/releases/tag/1.1.7) - 2019-08-06
 
 ### Fixed
+
 - If the excerpt does not have content it will show a trim version of the content as excerpt.
 - Travis and best practices fixes.
 
 ### Changed
-- Changing enqueuing scripts priority.
 
+- Changing enqueuing scripts priority.
 
 ## [[1.1.6]](https://github.com/lightspeeddevelopment/lsx-testimonials/releases/tag/1.1.6) - 2019-06-14
 
 ### Added
+
 - Changed the JS to trigger on page load and not right away.
 - Updating NPM Dependencies and package files.
 - Updating packages and making sure the border color for the block quote is grey.
 
 ### Fixed
+
 - Services will appear only if service plugin is active.
 - Updated the uix-core.js to remove the Cyclic error when saving the theme options
-
 
 ## [[1.1.5]](https://github.com/lightspeeddevelopment/lsx-testimonials/releases/tag/1.1.5) - 2018-08-28
 
 ### Deprecated
-- Remove the inline attributes for the "data-slick" attribute and marged them with the JS code.
 
+- Remove the inline attributes for the "data-slick" attribute and marged them with the JS code.
 
 ## [[1.1.4]](https://github.com/lightspeeddevelopment/lsx-testimonials/releases/tag/v1.1.4) - 2018-04-09
 
 ### Added
+
 - Removed the deprecated "create_function" call.
 
 ### Fixed
-- Fixing the broken method name 's_numeric'.
 
+- Fixing the broken method name 's_numeric'.
 
 ## [[1.1.1]]()
 
 ### Added
+
 - Added compatibility with LSX Videos.
 - Added compatibility with LSX Search.
 - Fixed PHP warning issues.
 
-
 ## [[1.1.0]]()
 
 ### Added
+
 - Added compatibility with LSX 2.0.
 - New project structure.
 - UIX copied from TO 1.1 + Fixed issue with sub tabs click (settings).
@@ -98,44 +109,46 @@
 - New single option - Featured post.
 
 ### Fixed
+
 - Fixed scripts/styles loading order.
 - Fixed small issues.
-
 
 ## [[1.0.4]]()
 
 ### Changed
+
 - Changed the "Insert into Post" button text from media modal to "Select featured image".
 
 ### Added
+
 - Updated NPM modules.
 - Added .editorconfig file.
 - Added complete language files.
 - Added carousel option to function and widget.
 
-
 ## [[1.0.3]]()
 
 ### Fixed
+
 - Testimonials Class error.
 - Testimonials Widget Class constructor.
 - Adjusted the plugin settings link inside the LSX API Class.
 
-
 ## [[1.0.2]]()
 
 ### Fixed
-- Fixed all prefixes replaces (to_ > lsx_to_, TO_ > LSX_TO_).
 
+- Fixed all prefixes replaces (to* > lsx_to*, TO* > LSX_TO*).
 
 ## [[1.0.1]]()
 
 ### Fixed
+
 - Reduced the access to server (check API key status) using transients.
 - Made the API URLs dev/live dynamic using a prefix "dev-" in the API KEY.
-
 
 ## [[1.0.0]]()
 
 ### Fixed
+
 - First Version.

--- a/classes/class-lsx-testimonials-widget.php
+++ b/classes/class-lsx-testimonials-widget.php
@@ -94,9 +94,7 @@ class LSX_Testimonials_Widget extends WP_Widget {
 		if ( $tagline ) {
 			echo '<p class="tagline text-center">' . esc_html( $tagline ) . '</p>';
 		}
-		if ( 'true' === $carousel || true === $carousel ) {
-			add_filter( 'lsx_lazyload_slider_images', array( $this, 'lazyload_slider_images' ), 10, 5 );
-		}
+
 		if ( class_exists( 'LSX_Testimonials' ) ) {
 			lsx_testimonials( array(
 				'columns'    => $columns,
@@ -111,9 +109,7 @@ class LSX_Testimonials_Widget extends WP_Widget {
 				'carousel'   => $carousel,
 				'featured'   => $featured,
 			) );
-			if ( 'true' === $carousel || true === $carousel ) {
-				remove_filter( 'lsx_lazyload_slider_images', array( $this, 'lazyload_slider_images' ), 10, 5 );
-			}
+
 		}
 
 		if ( $button_text && $title_link ) {
@@ -329,27 +325,6 @@ class LSX_Testimonials_Widget extends WP_Widget {
 		<?php
 	}
 
-	public function lazyload_slider_images( $img, $post_thumbnail_id, $size, $srcset, $image_url ) {
-		$lazyload = true;
-		if ( get_theme_mod( 'lsx_lazyload_status', '1' ) === false || ! apply_filters( 'lsx_lazyload_is_enabled', true ) ) {
-			$lazyload = false;
-		}
-		$lazy_img = '';
-		if ( true === $lazyload && '' !== $img ) {
-			$temp_lazy = wp_get_attachment_image_src( $post_thumbnail_id, $size );
-			if ( ! empty( $temp_lazy ) ) {
-				$lazy_img = $temp_lazy[0];
-			}
-			$img = '<img alt="' . the_title_attribute( 'echo=0' ) . '" class="attachment-responsive wp-post-image lsx-responsive" ';
-			if ( $srcset ) {
-				$img .= 'data-lazy="' . $lazy_img . '" srcset="' . esc_attr( $image_url ) . '" ';
-			} else {
-				$img .= 'data-lazy="' . esc_url( $image_url ) . '" ';
-			}
-			$img .= '/>';
-		}
-		return $img;
-	}
 }
 
 /**

--- a/classes/class-lsx-testimonials.php
+++ b/classes/class-lsx-testimonials.php
@@ -70,9 +70,9 @@ class LSX_Testimonials {
 
 		if ( empty( $thumbnail ) ) {
 			if ( $this->options['display'] && ! empty( $this->options['display']['testimonials_placeholder'] ) ) {
-				$thumbnail = '<img class="' . $responsive . '" src="' . $this->options['display']['testimonials_placeholder'] . '" width="' . $size . '" alt="placeholder" />';
+				$thumbnail = '<img loading="lazy" class="' . $responsive . '" src="' . $this->options['display']['testimonials_placeholder'] . '" width="' . $size . '" alt="placeholder" />';
 			} else {
-				$thumbnail = '<img class="' . $responsive . '" src="https://www.gravatar.com/avatar/none?d=mm&s=' . $size . '" width="' . $size . '" alt="placeholder" />';
+				$thumbnail = '<img loading="lazy" class="' . $responsive . '" src="https://www.gravatar.com/avatar/none?d=mm&s=' . $size . '" width="' . $size . '" alt="placeholder" />';
 			}
 		}
 


### PR DESCRIPTION
### Changes

Added support for native Lazy-loading images on WordPress 5.5 version.

### Benefits

- Support for WP 5.5 features.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Applicable Issues

https://github.com/lightspeeddevelopment/lsx/issues/425

### Changelog Entry

#### Added
- Added support for native Lazy-loading images on WordPress 5.5 version.
