### PR TITLE
Updating the version number for WP 6.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,14 +1,19 @@
 # Change log
 
-## [[1.3.5]](https://github.com/lightspeeddevelopment/lsx-testimonials/releases/tag/1.3.5) - 2023-08-18
+## [[1.3.6]](https://github.com/lightspeeddevelopment/lsx-testimonials/releases/tag/1.3.6) - 2023-08-17
 
 ### Security
 - General testing to ensure compatibility with latest WordPress version (6.3).
 
-## [[1.3.4]](https://github.com/lightspeeddevelopment/lsx-testimonials/releases/tag/1.3.4) - 2023-04-20
+## [[1.3.5]](https://github.com/lightspeeddevelopment/lsx-testimonials/releases/tag/1.3.5) - 2023-04-20
 
 ### Security
 - General testing to ensure compatibility with latest WordPress version (6.2).
+
+## [[1.3.4]](https://github.com/lightspeeddevelopment/lsx-testimonials/releases/tag/1.3.4) - 2022-12-23
+
+### Security
+- General testing to ensure compatibility with latest WordPress version (6.1.1).
 
 ## [[1.3.3]](https://github.com/lightspeeddevelopment/lsx-testimonials/releases/tag/1.3.3) - 2022-09-21
 

--- a/lsx-testimonials.php
+++ b/lsx-testimonials.php
@@ -3,7 +3,7 @@
  * Plugin Name: LSX Testimonials
  * Plugin URI:  https://lsx.lsdev.biz/extensions/testimonials/
  * Description: The LSX Testimonials extension adds the "Testimonials" post type.
- * Version:     1.3.5
+ * Version:     1.3.6
  * Author:      LightSpeed
  * Author URI:  https://www.lsdev.biz/
  * License:     GPL3
@@ -20,7 +20,7 @@ if ( ! defined( 'WPINC' ) ) {
 define( 'LSX_TESTIMONIALS_PATH', plugin_dir_path( __FILE__ ) );
 define( 'LSX_TESTIMONIALS_CORE', __FILE__ );
 define( 'LSX_TESTIMONIALS_URL', plugin_dir_url( __FILE__ ) );
-define( 'LSX_TESTIMONIALS_VER', '1.3.5' );
+define( 'LSX_TESTIMONIALS_VER', '1.3.6' );
 
 
 /* ======================= Below is the Plugin Class init ========================= */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsx-testimonials",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Testimonials for LSX",
   "main": "gulpfile.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: lsx, gutenberg, testimonials, post type, carousel
 Requires at least: 5.0
 Requires PHP: 7.0
 Tested up to: 6.3
-Stable tag: 1.3.5
+Stable tag: 1.3.6
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 


### PR DESCRIPTION
### Description

- Updating the stable tag and version number
- Security Testing for 1.3.6